### PR TITLE
Un-nerfs leg augmentation.

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -355,7 +355,7 @@
 	var/nerve_eff = max(owner.get_specific_organ_efficiency(OP_NERVE, organ_tag),1)
 	muscle_eff = (muscle_eff/100) - (muscle_eff/nerve_eff) //Need more nerves to control those new muscles
 	if(muscle_eff)
-		. -= 0.6 * muscle_eff / (muscle_eff + 0.4) // Diminishing returns with a hard cap of 0.6 and soft cap of 0.5
+		. += max(-(muscle_eff), MAX_MUSCLE_SPEED)
 	. += tally
 
 /obj/item/organ/external/proc/is_nerve_struck()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Augmented people should now have their speed returned.

## Why It's Good For The Game

Humon overnerfed it to the point where they become useless, Just one bullet hitting an augmented limb (especially with an extra nerve) will make them instantly unconscious already and we have #8176 so over-nerfing wasn't needed. This makes it more fitting for productive type people rather than combat types. It's great for megascale engineering projects and so you don't have to go way, WAY back just to get that one thing you forgot to grab

## Testing

Implanted two extra muscles and nerves in my legs and achieved the original speed as before.

## Changelog
:cl:
balance: Returned leg augmentation speed to it's original value.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->